### PR TITLE
Adding the keyboard blocking class

### DIFF
--- a/dist/js/perfect-scrollbar.js
+++ b/dist/js/perfect-scrollbar.js
@@ -509,7 +509,7 @@ function bindKeyboardHandler(element, i) {
   }
 
     i.event.bind(i.ownerDocument, 'keydown', function(e) {
-        if (element.classList.contains("ps-disabled") ) {
+        if (element.classList.contains('ps-disabled') || element.classList.contains('ps-ignore-keys')) {
             return;
         }
     if ((e.isDefaultPrevented && e.isDefaultPrevented()) || e.defaultPrevented) {


### PR DESCRIPTION
Adding class `ps-ignore-keys` for the cases when the scrollbar still should be enabled, but the keys are handled in different place 
